### PR TITLE
Added check on /dev/mmcblk0p1, p2, and p3 before attempting to check …

### DIFF
--- a/recipes-core/initrdscripts/tegra-minimal-init-live.blob/init-boot.sh
+++ b/recipes-core/initrdscripts/tegra-minimal-init-live.blob/init-boot.sh
@@ -49,6 +49,26 @@ main(){
       count=`expr $count + 1`
     done
   fi
+
+  # Allow 10 seconds to make sure that the partitions have been mounted
+  count=0
+  success=0
+  echo "Checking to make sure mmcblk0p1, p2, and p3 are mounted" > /dev/kmsg
+  while [ $count -lt 100 ]; do
+    if [[ -e /dev/mmcblk0p1 && -e /dev/mmcblk0p2 && -e /dev/mmcblk0p3 ]]; then
+      echo "mmcblk0p1, p2, and p3 are mounted! Starting TMR..." > /dev/kmsg
+      success=1
+      break
+    fi
+    sleep 0.1
+    count=`expr $count + 1`
+  done
+  # Reboot immediately if they were not mounted so we do not accidentally
+  # try to correct the blobs with garbage
+  if [ $success = 0 ]; then
+    echo "mmcblk0p1, p2, and p3 were not mounted! Rebooting..." > /dev/kmsg
+    reboot -f
+  fi
   
   # Set up the variables needed to do the TMR checks and corrections 
   num_partitions="3"


### PR DESCRIPTION
…files in order to prevent catastrohic failure.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Implemented a check to ensure essential partitions are mounted before starting critical processes. If not, the system will reboot to prevent data corruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->